### PR TITLE
Fix for OUJS

### DIFF
--- a/sbl.user.js
+++ b/sbl.user.js
@@ -2,6 +2,7 @@
 // @name        sweetbooklists
 // @namespace   zeratax@firemail.cc
 // @description Exports a list of books by the given search parameters from tsumino
+// @license     GPL-3.0
 // @include     http://www.tsumino.com/*
 // @include     http://tsumino.com/*
 // @exclude     http://tsumino.com/Forum/*


### PR DESCRIPTION
OUJS has made a change recently to require SPDX codes for OSI approved licensing.

In order to improve the appearance of your script homepages it would be appreciated if you could modify all of your affected scripts.

Until this change is made you will be unable to update those affected scripts.

Thanks,
OUJS Staff